### PR TITLE
bump VTK to 9.6.2 to enable Python 3.14 wheels

### DIFF
--- a/.github/workflows/build-ocp.yml
+++ b/.github/workflows/build-ocp.yml
@@ -7,8 +7,8 @@ on: workflow_dispatch
 #       - v7.9
 
 env:
-  OCP: 7.9.3.1
-  WHEEL: 7.9.3.2
+  OCP: 7.9.3.1.1
+  WHEEL: 7.9.3.1.1
   VTK: 9.6.2
   VTK_MAJOR: 9.6
   OCCT: 7.9.3

--- a/.github/workflows/build-ocp.yml
+++ b/.github/workflows/build-ocp.yml
@@ -8,9 +8,9 @@ on: workflow_dispatch
 
 env:
   OCP: 7.9.3.1
-  WHEEL: 7.9.3.1
-  VTK: 9.5.2
-  VTK_MAJOR: 9.5
+  WHEEL: 7.9.3.2
+  VTK: 9.6.2
+  VTK_MAJOR: 9.6
   OCCT: 7.9.3
   PYBIND11: 2.13
   PYWRAP: "false"
@@ -37,9 +37,6 @@ jobs:
         os: ["ubuntu-22.04", "ubuntu-22.04-arm"]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         use-vtk: ["vtk", "novtk"]
-        exclude:
-          - python-version: "3.14"
-            use-vtk: "vtk"
         include:
           - os: "ubuntu-22.04"
             runner: ubuntu-latest
@@ -71,9 +68,6 @@ jobs:
         os: ["macos-15-intel", "macos-15", "windows-2022"]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         use-vtk: ["vtk", "novtk"]
-        exclude:
-          - python-version: "3.14"
-            use-vtk: "vtk"
         include:
           - os: "macos-15"
             vtk-libs: ".dylibs/libvtk*.dylib"
@@ -222,9 +216,6 @@ jobs:
         os: ["ubuntu-22.04", "ubuntu-22.04-arm"]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         use-vtk: ["vtk", "novtk"]
-        exclude:
-          - python-version: "3.14"
-            use-vtk: "vtk"
         include:
           - os: "ubuntu-22.04"
             runner: ubuntu-latest
@@ -259,9 +250,6 @@ jobs:
         os: ["macos-15-intel", "macos-15", "windows-2022"]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         use-vtk: ["vtk", "novtk"]
-        exclude:
-          - python-version: "3.14"
-            use-vtk: "vtk"
         include:
           - os: "macos-15"
             delocate: delocate
@@ -321,9 +309,6 @@ jobs:
           ]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         use-vtk: ["vtk", "novtk"]
-        exclude:
-          - python-version: "3.14"
-            use-vtk: "vtk"
         include:
           - os: "macos-15-intel"
             runner: macos-15-intel


### PR DESCRIPTION
I took the liberty of opening this PR proactively, please feel free to close if it's not the right form or timing.

## Summary

VTK 9.6.0+ ships `cp314` wheels on PyPI (since 2026-02-11). Bumping the pinned VTK from `9.5.2` to `9.6.2` and dropping the `python-version: "3.14"` matrix excludes is sufficient to produce `cadquery-ocp` wheels for Python 3.14.
Related to #56.

## Changes

- `VTK: 9.5.2` -> `9.6.2`, `VTK_MAJOR: 9.5` -> `9.6`
- Drop 5 `exclude: python-version: "3.14" / use-vtk: "vtk"` matrix rows
- `WHEEL: 7.9.3.1` -> `7.9.3.1.1` (see note below)
- No source regeneration, no OCCT bump, no pybind11 bump, no patch changes

## Notes

Tested locally end-to-end on Linux x86_64 (ubuntu:20.04 container, mirrors the CI setup):

- OCCT 7.9.3 SDK compiles clean against VTK 9.6.2 headers
- Pre-generated OCP 7.9.3.1 source compiles clean (only references `vtkActor.h`, `vtkInformationObjectBaseKey.h`, `vtkRenderer.h`, all stable)
- Resulting wheel: `cadquery_ocp-7.9.3.2-cp314-cp314-manylinux_2_31_x86_64.whl`
- `import OCP` works, `BRepPrimAPI_MakeBox` + STEP export produce valid output
- `cadquery 2.7.0` on top: `Workplane.box(10,20,30).hole(5)` returns correct
  volume (5410.95), STEP export writes a 20 KB file

macOS and Windows still need CI validation.

I bumped `WHEEL` to `7.9.3.2`, change if you'd rather do it differently.

EDIT: 7.9.3.1.1