### PR TITLE
skip vtk.libs copy when missing

### DIFF
--- a/.github/actions/build-sdks/action.yml
+++ b/.github/actions/build-sdks/action.yml
@@ -172,7 +172,7 @@ runs:
         cp $CONDA_PREFIX/lib/python$PY_VER/site-packages/vtkmodules/${{ inputs.vtk-libs }} $DEST/lib/
         cp $CONDA_PREFIX/lib/python$PY_VER/site-packages/vtk.py $DEST
 
-        if [[ "$RUNNER_OS" == "Linux" ]]; then
+        if [[ "$RUNNER_OS" == "Linux" && -d $CONDA_PREFIX/lib/python$PY_VER/site-packages/vtk.libs ]]; then
           cp $CONDA_PREFIX/lib/python$PY_VER/site-packages/vtk.libs/* $DEST/lib/
         fi
 


### PR DESCRIPTION
Follow-up to #60. VTK 9.6 wheels no longer ship a `vtk.libs/` directory (deps consolidated into `vtkmodules/`), so the unconditional copy fails on Linux. Adds a directory existence guard.

Verified locally with `vtk==9.6.2` for cp310-cp314 on Linux x86_64. macOS and Windows paths are unaffected.