### PR TITLE
update actions versions, pin SHAs for security

### DIFF
--- a/.github/actions/build-ocp-source/action.yml
+++ b/.github/actions/build-ocp-source/action.yml
@@ -13,13 +13,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
 
     # - - -
 
     - name: Restore OCP source cache
       id: cache-ocp-source-restore
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
       with:
         path: ${{ github.workspace }}/OCP
         key: OCP-source-${{ env.OCP }}-vtk-${{ inputs.os }}
@@ -58,7 +58,7 @@ runs:
 
     - name: Set up Python ${{ inputs.python-version }} via micromamba [PYWRAP=true]
       if: env.PYWRAP == 'true' && steps.cache-ocp-source-restore.outputs.cache-hit != 'true'
-      uses: mamba-org/setup-micromamba@v3
+      uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 #v3.1.0
       with:
         environment-file: environment-pywrap-${{ inputs.python-version }}.yml
         log-level: warning
@@ -183,7 +183,7 @@ runs:
 
     - name: Cache OCP source folder
       id: cache-ocp-source-save
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
       with:
         path: ${{ github.workspace }}/OCP
         key: ${{ steps.cache-ocp-source-restore.outputs.cache-primary-key }}
@@ -191,7 +191,7 @@ runs:
     # - - -
 
     - name: Upload OCP source
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
       with:
         name: OCP-source_${{ env.OCP }}-${{ inputs.os }}
         path: ./OCP
@@ -202,7 +202,7 @@ runs:
 
     - name: Install uv
       if: env.PYWRAP == 'false'
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 #v9.0.0
       with:
         python-version: "3.12"
         # enable-cache: true
@@ -231,7 +231,7 @@ runs:
 
     - name: Upload cadquery_ocp stubs wheel
       if: env.PYWRAP == 'false'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
       with:
         name: cadquery-ocp-${{ env.WHEEL }}-stubs-${{ inputs.os }}
         path: pypi-stubs/dist/*.whl  

--- a/.github/actions/build-ocp/action.yml
+++ b/.github/actions/build-ocp/action.yml
@@ -33,7 +33,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
 
     # - - - - - - - - - - - - - - - - - - - - -
     # Install dependencies
@@ -66,7 +66,7 @@ runs:
 
     
     - name: Set up Python ${{ inputs.python-version }} via micromamba
-      uses: mamba-org/setup-micromamba@v3
+      uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 #v3.1.0
       with:
         environment-file: environment.yml
         log-level: warning
@@ -106,7 +106,7 @@ runs:
     - name: Restore VTK SDK cache
       if: inputs.use-vtk == 'vtk'
       id: cache-vtk-restore
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
       with:
         path: |
           ~/opt/local/vtk-${{ env.VTK }}
@@ -115,7 +115,7 @@ runs:
     
     - name: Restore OCCT SDK cache with VTK support
       id: cache-occt-restore
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
       with:
         path: |
           ~/opt/local/occt-${{ env.OCCT }}-${{ inputs.use-vtk }}
@@ -128,14 +128,14 @@ runs:
     # OCP sources are cached by build-ocp-source action
     - name: Restore OCP source cache
       id: cache-ocp-source-restore
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
       with:
         path: ${{ github.workspace }}/OCP
         key: OCP-source-${{ env.OCP }}-vtk-${{ inputs.ocp-source-tag }}
 
     - name: Restore OCP module cache
       id: cache-ocp-restore
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
       with:
         path: ${{ github.workspace }}/OCP/build/${{ inputs.module }}
         key: OCP-${{ env.OCP }}-VTK-${{ inputs.use-vtk }}-${{ inputs.os }}-py${{ inputs.python-version }}-
@@ -312,13 +312,13 @@ runs:
     
     - name: Cache OCP module
       id: cache-ocp-save
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
       with:
         path: ${{ github.workspace }}/OCP/build/${{ inputs.module }}
         key: ${{ steps.cache-ocp-restore.outputs.cache-primary-key }}
 
     # - name: Debug Upload module
-    #   uses: actions/upload-artifact@v4
+    #   uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
     #   with:
     #     name: debug_module_${{ inputs.os }}-${{ inputs.use-vtk }}-py_${{ inputs.python-version }}
     #     path: ./OCP/build/${{ inputs.module }}
@@ -515,7 +515,7 @@ runs:
     
     - name: Upload vtk cadquery_ocp wheel
       if: inputs.use-vtk == 'vtk'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
       with:
         name: cadquery-ocp-${{ env.WHEEL }}-${{ inputs.os }}-cp${{ inputs.python-version }}
         path: pypi/wheel/*.whl
@@ -523,7 +523,7 @@ runs:
     
     - name: Upload novtk cadquery_ocp wheel
       if: inputs.use-vtk == 'novtk'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
       with:
         name: cadquery-ocp-novtk-${{ env.WHEEL }}-${{ inputs.os }}-cp${{ inputs.python-version }}
         path: pypi/wheel/*.whl  

--- a/.github/actions/build-sdks/action.yml
+++ b/.github/actions/build-sdks/action.yml
@@ -26,14 +26,14 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
  
     # - - -
 
     - name: Restore VTK SDK cache
       if: inputs.use-vtk == 'vtk'
       id: cache-vtk-restore
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
       with:
         path: |
           ~/opt/local/vtk-${{ env.VTK }}
@@ -43,7 +43,7 @@ runs:
 
     - name: Restore OCCT SDK cache
       id: cache-occt-restore
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
       with:
         path: |
           ~/opt/local/occt-${{ env.OCCT }}-${{ inputs.use-vtk }}
@@ -72,7 +72,7 @@ runs:
 
     - name: Set up Python ${{ inputs.python-version }} via micromamba
       if: steps.cache-occt-restore.outputs.cache-hit != 'true'
-      uses: mamba-org/setup-micromamba@v3
+      uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 #v3.1.0
       with:
         environment-file: environment.yml
         log-level: warning
@@ -216,7 +216,7 @@ runs:
     - name: Cache VTK build folder
       if: inputs.use-vtk == 'vtk'
       id: cache-vtk-save
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
       with:
         path: |
           ~/opt/local/vtk-${{ env.VTK }}
@@ -410,7 +410,7 @@ runs:
 
     - name: Cache OCCT build folder
       id: cache-occt-save
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
       with:
         path: |
           ~/opt/local/occt-${{ env.OCCT }}-${{ inputs.use-vtk }}
@@ -421,9 +421,8 @@ runs:
     # ================================================================================
 
     # - - -
-
     # - name: Upload SDK
-    #   uses: actions/upload-artifact@v4
+    #   uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
     #   with:
     #     name: SDK_${{ inputs.os }}-py_${{ inputs.python-version }}-${{ inputs.use-vtk }}
     #     path: ~/opt/local

--- a/.github/actions/test-ocp/action.yml
+++ b/.github/actions/test-ocp/action.yml
@@ -14,12 +14,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
     
     # - - -
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 #v9.0.0
       with:
         python-version: ${{ matrix.python-version }}
         enable-cache: false
@@ -37,7 +37,7 @@ runs:
     
     - name: Download vtk cadquery_ocp wheel
       if: inputs.use-vtk == 'vtk'
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
       with:
         name: cadquery-ocp-${{ env.WHEEL }}-${{ inputs.os }}-cp${{ inputs.python-version }}
 
@@ -45,21 +45,21 @@ runs:
 
     - name: Download novtk cadquery_ocp wheel
       if: inputs.use-vtk == 'novtk'
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
       with:
         name: cadquery-ocp-novtk-${{ env.WHEEL }}-${{ inputs.os }}-cp${{ inputs.python-version }}
 
     # - - -
 
     - name: Download cadquery_ocp_proxy wheel
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
       with:
         name: cadquery-ocp-proxy-${{ env.WHEEL }}-cp-${{ matrix.python-version }}
 
     # - - -
 
     - name: Download cadquery_ocp_stubs wheel
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
       with:
         name: cadquery-ocp-${{ env.WHEEL }}-stubs-${{ inputs.os == 'macos-15-intel' && 'macos-15' || (inputs.os == 'ubuntu-22.04-arm' && 'ubuntu-22.04' || inputs.os) }}
 

--- a/.github/workflows/build-ocp.yml
+++ b/.github/workflows/build-ocp.yml
@@ -44,7 +44,7 @@ jobs:
             runner: ubuntu-24.04-arm
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
 
       - name: Build SDKs
         id: build-sdks
@@ -86,7 +86,7 @@ jobs:
             shells: "bash cmd.exe"
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
 
       - name: Build SDKs
         id: build-sdks
@@ -124,7 +124,7 @@ jobs:
             plat: "manylinux_2_31_x86_64 manylinux_2_31_aarch64"
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
       - name: Build or download OCP Source
         id: build-ocp-source
         uses: ./.github/actions/build-ocp-source
@@ -149,7 +149,7 @@ jobs:
             plat: "win_amd64"
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
       - name: Build or download OCP Source
         id: build-ocp-source
         uses: ./.github/actions/build-ocp-source
@@ -172,10 +172,10 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 #v9.0.0
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
@@ -193,7 +193,7 @@ jobs:
           uv build
 
       - name: Upload cadquery_ocp_proxy wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
           name: cadquery-ocp-proxy-${{ env.WHEEL }}-cp-${{ matrix.python-version }}
           path: cadquery_ocp_proxy/dist/*.whl
@@ -225,7 +225,7 @@ jobs:
             plat: manylinux_2_31_aarch64
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
       - name: Build OCP
         id: build-ocp
         uses: ./.github/actions/build-ocp
@@ -272,7 +272,7 @@ jobs:
             module: "OCP.*.pyd"
             ocp-source-tag: "windows-2022"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
       - name: Build OCP
         id: build-ocp
         uses: ./.github/actions/build-ocp
@@ -322,7 +322,7 @@ jobs:
             runner: windows-2022
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
       - name: Test OCP
         id: test-ocp
         uses: ./.github/actions/test-ocp
@@ -343,12 +343,12 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
         if: env.RELEASE_TO_REPO == 'true'
 
       - name: Download all wheel artifacts
         if: env.RELEASE_TO_REPO == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
         with:
           path: wheels
           pattern: cadquery-*
@@ -356,7 +356,7 @@ jobs:
 
       - name: Create release
         if: env.RELEASE_TO_REPO == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 #v3.0.2
         with:
           tag_name: v${{ env.WHEEL }}
           name: Release ${{ env.WHEEL }}

--- a/.github/workflows/local-build.yml
+++ b/.github/workflows/local-build.yml
@@ -20,11 +20,11 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
 
       # see https://github.com/marketplace/actions/setup-miniconda
       - name: Setup Conda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 #v4.0.1
         with:
           #miniforge-version: latest
           miniconda-version: latest
@@ -71,7 +71,7 @@ jobs:
 
       # see https://github.com/marketplace/actions/upload-a-build-artifact
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
           name: cadquery-ocp-${{ matrix.os }}-cp${{ matrix.python-version }}
           path: dist/*.whl


### PR DESCRIPTION
- Some current actions versions are old and will stop functioning in Fall 2026 because of Node 20 dependency. I updated all actions to the most recent releases.
  - Current actions versions are technically vulnerable to a supply chain attack since they do not pin the SHA version
  - There are a number of security improvements in the more recent actions versions.